### PR TITLE
Escape special characters in passwords when executing mysqldump command

### DIFF
--- a/src/MysqlPlugin.php
+++ b/src/MysqlPlugin.php
@@ -134,7 +134,7 @@ class MysqlPlugin implements PluginInterface
         return sprintf(
             'mysqldump -u%s %s %s > %s',
             $username,
-            isset($password) ? ('-p' . ($hidePassword ? '***' : $password)) : '',
+            isset($password) ? ('-p' . ($hidePassword ? '***' : "'".addcslashes($password, "'")."'")) : '',
             $database,
             $file
         );


### PR DESCRIPTION
`nanbando backup` creates a backup with empty `dump.sql` file when using MySQL passwords with special characters. The issue arises because this plugin is not escaping those extra characters internally when executing `mysqldump` command.
Before the fix, the generated dump command looks something like this:
`mysqldump -uUser -pPa$$'word`
After this fix applied:
`mysqldump -uUser -p'Pa$$\'word'`
